### PR TITLE
Django 2.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ DRY Rest Permissions allows developers to easily describe what gives someone per
 
 ## Requirements
 
--  Python (2.7, 3.4+)
--  Django (1.8, 1.10)
--  Django REST Framework (3.5, 3.6)
+-  Python (3.4+)
+-  Django (1.11, 2.0)
+-  Django REST Framework (3.5, 3.6, 3.7)
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,9 +37,9 @@ DRY Rest Permissions allows developers to easily describe what gives someone per
 
 ##Requirements
 
--  Python (2.7)
--  Django (1.7, 1.8, 1.9)
--  Django REST Framework (3.0, 3.1)
+-  Python (3.4+)
+-  Django (1.11, 2.0)
+-  Django REST Framework (3.5, 3.6, 3.7)
 
 ##Installation
 

--- a/dry_rest_permissions/generics.py
+++ b/dry_rest_permissions/generics.py
@@ -302,7 +302,7 @@ def authenticated_users(func):
         if is_object_permission:
             request = args[1]
 
-        if not(request.user and request.user.is_authenticated()):
+        if not(request.user and request.user.is_authenticated):
             return False
 
         return func(*args, **kwargs)
@@ -324,7 +324,7 @@ def unauthenticated_users(func):
         if is_object_permission:
             request = args[1]
 
-        if request.user and request.user.is_authenticated():
+        if request.user and request.user.is_authenticated:
             return False
 
         return func(*args, **kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Minimum Django and REST framework version
-Django>=1.6
+Django>=1.11
 djangorestframework>=2.4.3
 
 # Test requirements

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,6 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
        py27-{flake8,docs},
-       py{27,34,35,36}-django{1.8,1.10}-drf{3.5,3.6}
+       py{34,35,36}-django{1.11}-drf{3.5,3.6}
+       py{34,35,36}-django{2}-drf{3.7}
 
 
 [testenv]
@@ -9,10 +10,11 @@ commands = ./runtests.py --fast
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
-       django1.8: Django>=1.8,<1.9
-       django1.10: Django>=1.10,<1.11
+       django1.11: Django>=1.11,<2.0
+       django2: Django>=2.0,<3.0
        drf3.5: djangorestframework>=3.5,<3.6
        drf3.6: djangorestframework>=3.6,<3.7
+       drf3.7: djangorestframework>=3.7,<3.8
        pytest-django==3.1.2
 
 [testenv:py27-flake8]


### PR DESCRIPTION
`is_authenticated` is now a property only (was a function and both since 1.11).
This breaks compatibility with django < 1.11.

TODO: Update tests etc.